### PR TITLE
Changed cloning location for the Vizzy packages & updated the installation troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ Once the setup is complete and your terminal environment is updated:
             ```
         * If errors persist, it might be related to a specific Gazebo version or system configuration. Please open an issue with details.
 * **Package not found / Command not found:** Ensure you have sourced `~/.bashrc` in your current terminal or opened a new terminal after the installation.
+* **Problems with `sudo apt-get upgrade -y`:** This issue can occur during the `ROS 2 installation` phase (Step 4) of the installation. To resolve this, just run on the terminal:
+  ```bash
+  sudo apt-get update --fix-missing
+  ```
+    and then you can restart the installation process with:
+    ```bash
+    ./full_installer.sh
+    ```

--- a/full_installer.sh
+++ b/full_installer.sh
@@ -160,11 +160,12 @@ if [ ! -z "$NEW_COLCON_WS" ]; then
 fi
 echo "[Step 11] Setting up colcon workspace at $COLCON_WS..."
 # Define the target src directory.
-TARGET_SRC_DIR="$COLCON_WS/src"
+TARGET_SRC_DIR="$COLCON_WS/src/vizzy2"
 # Ensure the src directory exists.
 mkdir -p "$TARGET_SRC_DIR"
 # Change to the src directory to perform the clone.
 cd "$TARGET_SRC_DIR"
+echo "[INFO] Navigated into $TARGET_SRC_DIR."
 # Check if the current directory (src) is already a git repository.
 # We look for the .git folder which indicates the root of a git repository.
 if [ ! -d ".git" ]; then


### PR DESCRIPTION
Change Vizzy Packages Paths & Update Installation Troubleshooting
-

Key changes for this commit include:

### Troubleshooting Documentation Enhancement

-   **`README.md`**: Added a known issue and its corresponding solution to the troubleshooting section. This addresses a problem that can be encountered during the `ROS 2 installation` process (step 4).

### Vizzy Packages Cloning Location Change

-   **`full_installer.sh`**: Modified the cloning directory for the `vizzy2.0` repository packages.

    -   **Previous location:**
        ```
        vizzy2_ws/
        └── src/
            ├── vizzy_description/
            ├── vizzy_gazebo/
            ├── vizzy_launch/
            ├── vizzy_msgs/
            └── vizzy_navigation/
        ```

    -   **New location:**
        ```
        vizzy2_ws/
        └── src/
            └── vizzy2/
                ├── vizzy_description/
                ├── vizzy_gazebo/
                ├── vizzy_launch/
                ├── vizzy_msgs/
                └── vizzy_navigation/
        ```

    -   **Reason for change:** This new structure standardizes the vizzy-specific packages location under a parent `vizzy2` directory within `src/`. This approach is crucial for enabling the seamless integration and usage of other Git repositories within the same Colcon workspace without leading to potential git conflicts.

### How to Test

1.  Delete the current Colcon Workspace specified in the previous installation of the project.
2.  Run the `full_installer.sh` script on a clean environment and wait for it to terminate.
3.  Confirm that no issues were encountered.
4.  Verify that the `vizzy2` packages are cloned into `vizzy2_ws/src/vizzy2/`.
5.  Review the new troubleshooting entry in `README.md` for clarity and accuracy.
